### PR TITLE
Image viewer svg annotation 184206679

### DIFF
--- a/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
+++ b/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
@@ -49,28 +49,25 @@ class LayeredImageViewer {
   _processImages(type, imgEls) {
     if (!imgEls.length) return;
 
-    // Store url, alt and title
+    // Store state required for each type
     imgEls.forEach((imgEl, i) => {
-      const url = imgEl.src;
-      let alt = imgEl.alt;
-      let label = 'Unknown';
       const figureEl = imgEl.closest('figure');
+      const itemState = {};
+      itemState.url = imgEl.src;
+      itemState.alt = imgEl.alt;
+      itemState.label = 'Unknown';
 
       // Handle either figcaption or title
       if (imgEl.title) {
-        label = imgEl.title;
+        itemState.label = imgEl.title;
       } else if (figureEl && figureEl.querySelector('figcaption')) {
-        label = figureEl.querySelector('figcaption').innerText;
+        itemState.label = figureEl.querySelector('figcaption').innerText.trim();
       }
 
       // Add ID for internal reference
       imgEl.id = `layered-image-viewer-${this.id}-${type}-${i}`;
 
-      this[type].items = this[type].items.concat({
-        url,
-        alt,
-        label,
-      });
+      this[type].items = this[type].items.concat(itemState);
     });
   }
 

--- a/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
+++ b/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
@@ -358,6 +358,14 @@ class LayeredImageViewer {
     // Reset
     this.toolbar.buttons.reset.addEventListener('click', () => {
       this.viewer.viewport.goHome();
+
+      // Deactivate annotations
+      // (Requires events to be dispatched manually to trigger)
+      const changeEvent = new Event('change');
+      this.annotations.items.forEach((annotation) => {
+        annotation.checkboxEl.checked = false;
+        annotation.checkboxEl.dispatchEvent(changeEvent);
+      });
     });
 
     // Control panel for annotations if present
@@ -394,9 +402,10 @@ class LayeredImageViewer {
         `;
 
       const rowEl = fieldTemplate.content.firstElementChild;
+      this.annotations.items[i].checkboxEl = rowEl.firstElementChild;
 
       // Attach toggle handling
-      rowEl.firstElementChild.addEventListener('change', (e) => {
+      this.annotations.items[i].checkboxEl.addEventListener('change', (e) => {
         if (e.target.checked) {
           // Turn overlay on
           this.activateAnnotation(e.target.dataset.index);

--- a/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
+++ b/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
@@ -184,21 +184,19 @@ class LayeredImageViewer {
    * @method
    */
   _insertPlaceholder() {
-    const placeholderEl = document.createElement('div');
-    const buttonEl = document.createElement('button');
-    const imgEl = document.createElement('img');
-    placeholderEl.classList.add('o-layered-image-viewer__placeholder');
-    buttonEl.classList.add('o-layered-image-viewer__launch');
-    buttonEl.type = 'button';
-    buttonEl.ariaLabel = 'Launch the layered image viewer';
-    buttonEl.id = `layered-image-viewer-${this.id}-launch`;
-    imgEl.src = this.images.items[0].url;
-    imgEl.alt = this.images.items[0].alt;
-    buttonEl.appendChild(imgEl);
-    placeholderEl.appendChild(buttonEl);
+    // Create template HTML
+    const placeholderTemplate = document.createElement('template');
+    placeholderTemplate.innerHTML = `
+      <div class="o-layered-image-viewer__placeholder">
+        <button id="layered-image-viewer-${this.id}-launch" class="o-layered-image-viewer__launch" type="button" aria-label="Launch the layered image viewer">
+          <img src="${this.images.items[0].url}" alt="${this.images.items[0].alt}"/>
+        </button>
+      </div>
+    `;
+    const placeholderEl = placeholderTemplate.content.firstElementChild;
 
     // Clicking placeholder to trigger fullscreen
-    buttonEl.addEventListener('click', () => {
+    placeholderEl.firstElementChild.addEventListener('click', () => {
       this._setFullscreen(true);
     });
 
@@ -214,17 +212,16 @@ class LayeredImageViewer {
   _initViewer() {
     // OSD expects no siblings, by having a mount element
     // the destroy() method will preserve the initial HTML
-    const mountEl = document.createElement('div');
-    this.mountEl = mountEl;
+    this.mountEl = document.createElement('div');
     this.mountEl.classList.add('o-layered-image-viewer__osd-mount');
-    this.element.insertAdjacentElement('beforeend', mountEl);
+    this.element.insertAdjacentElement('beforeend', this.mountEl);
 
     this.mountEl.style.display = 'block';
 
     // Initialise with default buttons / controls removed
     // See: http://openseadragon.github.io/docs/OpenSeadragon.html#.Options
     this.viewer = new OpenSeadragon({
-      element: mountEl,
+      element: this.mountEl,
       crossOriginPolicy: 'Anonymous',
       showSequenceControl: false,
       showHomeControl: false,
@@ -239,7 +236,7 @@ class LayeredImageViewer {
       },
     });
     this.mountEl.style.display = '';
-    mountEl.style.position = 'fixed';
+    this.mountEl.style.position = 'fixed';
 
     // TODO: Remove for production. Useful for debugging
     window.osd = OpenSeadragon;
@@ -329,14 +326,11 @@ class LayeredImageViewer {
     // Add each standard button and register with instance for easy access
     standardControls.forEach((control) => {
       const buttonEl = document.createElement('button');
-      const innerEl = document.createElement('span');
       buttonEl.type = 'button';
       buttonEl.classList.add(
         `o-layered-image-viewer__${LayeredImageViewer.toKebabCase(control)}`
       );
-      innerEl.classList.add('wrap');
-      innerEl.innerText = control;
-      buttonEl.appendChild(innerEl);
+      buttonEl.innerHTML = `<span class="wrap">${control}</span>`;
       this.toolbar.element.appendChild(buttonEl);
       this.toolbar.buttons[LayeredImageViewer.toCamelCase(control)] = buttonEl;
     });

--- a/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
+++ b/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
@@ -264,11 +264,6 @@ class LayeredImageViewer {
     this.mountEl.style.display = '';
     this.mountEl.style.position = 'fixed';
 
-    // TODO: Remove for production. Useful for debugging
-    window.osd = OpenSeadragon;
-    window.liv = this;
-    window.viewer = this.viewer;
-
     this.viewer.addHandler('open', () => {
       this._addControls();
 

--- a/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
+++ b/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
@@ -337,7 +337,7 @@ class LayeredImageViewer {
   }
 
   /**
-   * Transform an array of strings into a sentenace-like string
+   * Transform an array of strings into a sentence-like string
    * @public
    * @static
    * @method

--- a/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
+++ b/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
@@ -435,8 +435,16 @@ class LayeredImageViewer {
     // 2. Add an overlay. This works with imgs/svgs/html
     // There's also OpenSeadragon svgOverlay plugin, which from what I can tell
     // seems to be if you're working with arbitrary SVG code and not really suited to our files.
+
+    // Clone our annotation, otherwise OSD seems to want to move it
+    // (which makes destruction cleanup hard)
+    const cloneEl = this.annotations.element
+      .querySelector(`#layered-image-viewer-${this.id}-annotations-${index}`)
+      .cloneNode();
+    cloneEl.id = `layered-image-viewer-${this.id}-annotations-${index}-clone`;
+
     this.viewer.addOverlay({
-      id: `layered-image-viewer-${this.id}-annotations-${index}`,
+      element: cloneEl,
       location: new OpenSeadragon.Point(0, 0),
       width: 1, // (viewport unit)
       index: index,
@@ -453,7 +461,7 @@ class LayeredImageViewer {
     if (!this.annotations.items[index]) return;
 
     this.viewer.removeOverlay(
-      `layered-image-viewer-${this.id}-annotations-${index}`
+      `layered-image-viewer-${this.id}-annotations-${index}-clone`
     );
   }
 }

--- a/frontend/scss/organisms/_o-layered-image-viewer.scss
+++ b/frontend/scss/organisms/_o-layered-image-viewer.scss
@@ -45,3 +45,12 @@
   z-index: 99999;
   opacity: 0;
 }
+
+.layered-image-viewer-details {
+  background-color: #fff;
+
+  summary {
+    padding: 4px;
+    cursor: pointer;
+  }
+}

--- a/resources/views/components/organisms/_o-layered-image-viewer.blade.php
+++ b/resources/views/components/organisms/_o-layered-image-viewer.blade.php
@@ -61,5 +61,40 @@
             </figure>
         </div>
     </div>
-    <div class="o-layered-image-viewer__annotations"></div>
+    <div class="o-layered-image-viewer__annotations">
+        <div class="o-layered-image-viewer__annotation">
+          <figure class="m-media m-media--m m-media--contain">
+            <div class="m-media__img" data-behavior="fitText">
+              <div
+                class="m-media__contain--spacer"
+                style="padding-bottom: 62.5%"
+              ></div>
+              <img
+                src="https://res.cloudinary.com/ds4ie2hdu/image/upload/v1674586294/Whistler2_1912_141_NRM_anno-9_mfg79z.svg"
+                alt="Alt text for the first image"
+              />
+            </div>
+            <figcaption>
+              <div class="f-caption">Outline of main characters</div>
+            </figcaption>
+          </figure>
+        </div>
+        <div class="o-layered-image-viewer__annotation">
+          <figure class="m-media m-media--m m-media--contain">
+            <div class="m-media__img" data-behavior="fitText">
+              <div
+                class="m-media__contain--spacer"
+                style="padding-bottom: 62.5%"
+              ></div>
+              <img
+                src="https://res.cloudinary.com/ds4ie2hdu/image/upload/v1674586294/Whistler2_1912_141_IRG_anno-2_wuihg2.svg"
+                alt="Alt text for the second image"
+              />
+            </div>
+            <figcaption>
+              <div class="f-caption">Outline of hidden figure painted over</div>
+            </figcaption>
+          </figure>
+        </div>
+      </div>
 </div>


### PR DESCRIPTION
Adds control for toggling SVG annotations to the initial viewer.

The controls update the aria-label. At this stage I'm not using a live region to announce the changes, as it may not be strictly necessary. If this would be a useful improvement though we can look into adding it later.


Pivotal: https://www.pivotaltracker.com/story/show/184206679

