### PR TITLE
Embeddable viewer 184304845

### DIFF
--- a/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
+++ b/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
@@ -37,7 +37,6 @@ class LayeredImageViewer {
     this.boundExitFullscreenHandler = this._exitFullscreenHandler.bind(this);
 
     this.setInitialState();
-    this._insertPlaceholder();
     this._initViewer();
   }
 
@@ -178,32 +177,6 @@ class LayeredImageViewer {
   }
 
   /**
-   * Insert a thumbnail of the first image to launch the viewer
-   * @private
-   * @method
-   */
-  _insertPlaceholder() {
-    // Create template HTML
-    const placeholderTemplate = document.createElement('template');
-    placeholderTemplate.innerHTML = `
-      <div class="o-layered-image-viewer__placeholder">
-        <button id="layered-image-viewer-${this.id}-launch" class="o-layered-image-viewer__launch" type="button" aria-label="Launch the layered image viewer">
-          <img src="${this.images.items[0].url}" alt="${this.images.items[0].alt}"/>
-        </button>
-      </div>
-    `;
-    const placeholderEl = placeholderTemplate.content.firstElementChild;
-
-    // Clicking placeholder to trigger fullscreen
-    placeholderEl.firstElementChild.addEventListener('click', () => {
-      this._setFullscreen(true);
-    });
-
-    // If it was more complex than this I'd probably use inserAdjacentHTML
-    this.element.insertAdjacentElement('afterbegin', placeholderEl);
-  }
-
-  /**
    * Reach into the current state and set the aria-label for the viewer
    * @private
    * @method
@@ -296,9 +269,7 @@ class LayeredImageViewer {
       '.o-layered-image-viewer__osd-mount'
     );
     // Add elements we create here to be cleaned up
-    const fabricatedElements = viewerEl.querySelectorAll(
-      '.o-layered-image-viewer__placeholder'
-    );
+    const fabricatedElements = [];
 
     if (mountEl) {
       // Destroy OSD and remove elements added by this class
@@ -337,7 +308,7 @@ class LayeredImageViewer {
   }
 
   /**
-   * Transform an array of strings into a sentence-like string
+   * Transform an array of strings into a sentenace-like string
    * @public
    * @static
    * @method
@@ -370,7 +341,7 @@ class LayeredImageViewer {
     // (without really interacting with the OSD API)
     // N.B. Deliberate decision against role=toolbar for now, there is potentially complex behviour to handle if we apply that role
     // More info: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/toolbar_role
-    const standardControls = ['Exit', 'Zoom in', 'Zoom out', 'Reset'];
+    const standardControls = ['Zoom in', 'Zoom out', 'Reset', 'Fullscreen'];
     this.toolbar.element = document.createElement('div');
 
     // Add each standard button and register with instance for easy access
@@ -387,11 +358,6 @@ class LayeredImageViewer {
 
     // Add the completed toolbar to OSD
     this.viewer.controls.topright.appendChild(this.toolbar.element);
-
-    // Exit
-    this.toolbar.buttons.exit.addEventListener('click', () => {
-      this._setFullscreen(false);
-    });
 
     // Zoom In
     this.toolbar.buttons.zoomIn.addEventListener('click', () => {
@@ -416,6 +382,15 @@ class LayeredImageViewer {
         annotation.checkboxEl.checked = false;
         annotation.checkboxEl.dispatchEvent(changeEvent);
       });
+    });
+
+    // Fullscreen
+    this.toolbar.buttons.fullscreen.addEventListener('click', () => {
+      if (!this.isFullScreen) {
+        this._setFullscreen(true);
+      } else {
+        this._setFullscreen(false);
+      }
     });
 
     // Control panel for annotations if present
@@ -526,7 +501,6 @@ class LayeredImageViewer {
     );
   }
 }
-
 
 const layeredImageViewer = function(container) {
   this.init = function() {

--- a/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
+++ b/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
@@ -19,6 +19,9 @@ class LayeredImageViewer {
       typeof document.fullscreenElement !== 'undefined';
 
     this.id = 0;
+
+    this.captionTitleEl = null;
+    this.captionEl = null;
     this.images = {
       items: [],
       active: [], // Set() would've been useful here, but is not compatible with transpiler
@@ -87,6 +90,14 @@ class LayeredImageViewer {
     );
     this.annotations.element = this.element.querySelector(
       '.o-layered-image-viewer__annotations'
+    );
+
+    // Get caption and caption title nodes
+    this.captionTitleEl = this.element.querySelector(
+      '.o-layered-image-viewer__caption-title'
+    );
+    this.captionEl = this.element.querySelector(
+      '.o-layered-image-viewer__caption-text'
     );
 
     // Process each image

--- a/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
+++ b/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
@@ -235,7 +235,6 @@ class LayeredImageViewer {
       },
     });
     this.mountEl.style.display = '';
-    this.mountEl.style.position = 'fixed';
 
     this.viewer.addHandler('open', () => {
       this._addControls();

--- a/frontend/scss/molecules/_m-media.scss
+++ b/frontend/scss/molecules/_m-media.scss
@@ -321,8 +321,8 @@
   }
 }
 
-.m-media--m:not(.m-media--artwork) .m-media__img:not(.m-media--mirador-embed):not(.m-media--360-embed) img,
-.m-media--l:not(.m-media--artwork) .m-media__img:not(.m-media--mirador-embed):not(.m-media--360-embed) img,
+.m-media--m:not(.m-media--artwork) .m-media__img:not(.m-media--mirador-embed):not(.m-media--360-embed):not(.m-media--layered-image-viewer-embed) img,
+.m-media--l:not(.m-media--artwork) .m-media__img:not(.m-media--mirador-embed):not(.m-media--360-embed):not(.m-media--layered-image-viewer-embed) img,
 .m-media__img video,
 .m-media__img embed,
 .m-media:not(.m-media--soundcloud) .m-media__img iframe,

--- a/frontend/scss/organisms/_o-layered-image-viewer.scss
+++ b/frontend/scss/organisms/_o-layered-image-viewer.scss
@@ -14,8 +14,6 @@
 .o-layered-image-viewer__osd-mount {
   width: 100%;
   height: 100%;
-  max-height: 80vh;
-  aspect-ratio: 9 / 16;
 }
 
 .layered-image-viewer-details {
@@ -26,3 +24,27 @@
     cursor: pointer;
   }
 }
+
+.m-media--layered-image-viewer-embed {
+  height: 100%;
+  width: 100%;
+  max-height: 80vh;
+  aspect-ratio: 9 / 16;
+  background-image: none;;
+}
+
+// Initial modal state
+.layered-image-viewer-modal {
+  position: fixed;
+  width: 100vw;
+  height: 100vh;
+  max-width: none;
+  max-height: none;
+  padding: 0;
+  border: 0;
+  margin: 0;
+  opacity: 0;
+  -webkit-user-select: none;
+  user-select: none;
+}
+

--- a/frontend/scss/organisms/_o-layered-image-viewer.scss
+++ b/frontend/scss/organisms/_o-layered-image-viewer.scss
@@ -4,6 +4,12 @@
 }
 
 .js {
+  .o-layered-image-viewer {
+    width: 100%;
+    max-height: 80vh;
+    aspect-ratio: 4 / 3;
+  }
+
   .o-layered-image-viewer__images,
   .o-layered-image-viewer__annotations {
     display: none;
@@ -11,14 +17,8 @@
 }
 
 .o-layered-image-viewer__osd-mount {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  z-index: 99999;
+  width: 100%;
+  height: 100%;
 }
 
 .layered-image-viewer-details {

--- a/frontend/scss/organisms/_o-layered-image-viewer.scss
+++ b/frontend/scss/organisms/_o-layered-image-viewer.scss
@@ -10,31 +10,7 @@
   }
 }
 
-.o-layered-image-viewer__placeholder {
-  display: flex;
-  justify-content: center;
-  background-color: lightgray;
-
-  img {
-    display: block;
-    object-fit: contain;
-    max-height: 100vh;
-    width: 100%;
-  }
-}
-
-.o-layered-image-viewer__launch {
-  appearance: none;
-  display: block;
-  background: none;
-  border: 0;
-  padding: 0;
-  margin: 0;
-  cursor: pointer;
-}
-
 .o-layered-image-viewer__osd-mount {
-  display: none;
   position: fixed;
   top: 0;
   right: 0;
@@ -43,7 +19,6 @@
   width: 100vw;
   height: 100vh;
   z-index: 99999;
-  opacity: 0;
 }
 
 .layered-image-viewer-details {

--- a/frontend/scss/organisms/_o-layered-image-viewer.scss
+++ b/frontend/scss/organisms/_o-layered-image-viewer.scss
@@ -14,6 +14,8 @@
 .o-layered-image-viewer__osd-mount {
   width: 100%;
   height: 100%;
+  max-height: 80vh;
+  aspect-ratio: 9 / 16;
 }
 
 .layered-image-viewer-details {

--- a/frontend/scss/organisms/_o-layered-image-viewer.scss
+++ b/frontend/scss/organisms/_o-layered-image-viewer.scss
@@ -4,12 +4,7 @@
 }
 
 .js {
-  .o-layered-image-viewer {
-    width: 100%;
-    max-height: 80vh;
-    aspect-ratio: 4 / 3;
-  }
-
+  .o-layered-image-viewer__caption,
   .o-layered-image-viewer__images,
   .o-layered-image-viewer__annotations {
     display: none;

--- a/frontend/scss/state/_s-layered-image-viewer-active.scss
+++ b/frontend/scss/state/_s-layered-image-viewer-active.scss
@@ -3,44 +3,25 @@
 Layered image viewer active
 ============================
 
-Shows the image zoom area.
+When fullscreen / using modal on layered image viewer
 
 
 ***/
 
-.s-layered-image-viewer-active {
-  #a17 {
-    @media screen and (min-width: 1280px), screen and (min-height: 1024px) {
-      @supports (not (backdrop-filter: blur(5px))) and
-        (not (-webkit-backdrop-filter: blur(5px))) {
-        filter: blur(5px);
-      }
-    }
+.s-layered-image-viewer-modal-active {
+  body {
+    overflow: hidden;
   }
 
   .o-layered-image-viewer__osd-mount {
-    display: block;
+    background: $color__black--80;
+  }
+
+  .layered-image-viewer-modal {
     top: 0;
     left: 0;
     z-index: 9999;
-    background: $color__black--80;
     animation: reveal 0.3s normal forwards;
     opacity: 1;
-  }
-
-  .g-mask {
-    right: 0;
-    bottom: 0;
-
-    @supports (backdrop-filter: blur(5px)) or
-      (-webkit-backdrop-filter: blur(5px)) {
-      -webkit-backdrop-filter: blur(5px);
-      backdrop-filter: blur(5px);
-    }
-
-    @media screen and (min-width: 1280px), screen and (min-height: 1024px) {
-      background-color: rgba($color__black--80, 0.5);
-      opacity: 1;
-    }
   }
 }

--- a/resources/views/components/organisms/_o-layered-image-viewer.blade.php
+++ b/resources/views/components/organisms/_o-layered-image-viewer.blade.php
@@ -96,5 +96,13 @@
             </figcaption>
           </figure>
         </div>
+        <div class="o-layered-image-viewer__caption">
+            <div class="o-layered-image-viewer__caption-title">
+            <p>Fig 1.1</p>
+            </div>
+            <div class="o-layered-image-viewer__caption-text">
+            <p>The Artist in His Studio,1865/66, 1895</p>
+            </div>
+        </div>
       </div>
 </div>


### PR DESCRIPTION
Makes the viewer [embeddable](https://www.pivotaltracker.com/story/show/184304845) (i.e. usable right away rather than needing to be launched).

While implementing this I also did some other things:
1. Added the overall caption and caption title to the output as this was missing before
2. Reworked the placeholder button into a fullscreen button
3. Improved the accessibility of fullscreen when the native API is not supported (for our purposes this is primarily iPhones). This needs to create a focus trap, and prevent navigation outside of the modal. The dialog provides this and implicitly uses the `inert` attribute.
4. Simplified the styling, and way scrolling is prevented to stop [this bug from happening](https://www.pivotaltracker.com/story/show/184313848)