### PR TITLE
Zoom initial state 184304798

### DIFF
--- a/resources/views/components/molecules/_m-layered-image-viewer-layer.blade.php
+++ b/resources/views/components/molecules/_m-layered-image-viewer-layer.blade.php
@@ -85,7 +85,7 @@
             @endif
 
             {{-- Important to include this, must be largest size available: --}}
-            data-viewer-src="{{ $media['src'] }}"
+            data-viewer-src="{{ $media['full_src'] }}"
         />
     </div>
     @if (isset($item['label']))

--- a/resources/views/components/organisms/_o-layered-image-viewer.blade.php
+++ b/resources/views/components/organisms/_o-layered-image-viewer.blade.php
@@ -1,4 +1,4 @@
-<div class="o-layered-image-viewer{{ (isset($variation)) ? ' '.$variation : '' }}" data-size="{{ (isset($size)) ? $size : 'm' }}" data-behavior="layeredImageViewer">
+<div class="o-layered-image-viewer{{ (isset($variation)) ? ' '.$variation : '' }}" data-size="{{ (isset($size)) ? $size : 'm' }}" {!! isset($cropRegion) ? 'data-crop-region="' . $cropRegion . '"' : '' !!} data-behavior="layeredImageViewer">
     @if (isset($images) && !empty($images))
         <div class="o-layered-image-viewer__images o-blocks__block">
             @foreach ($images as $image)

--- a/resources/views/site/blocks/layered_image_viewer.blade.php
+++ b/resources/views/site/blocks/layered_image_viewer.blade.php
@@ -2,15 +2,30 @@
     $captionTitle = $block->present()->input('caption_title');
     $captionText = $block->present()->input('caption');
     $size = $block->present()->input('size');
-
     $images = [];
     $overlays = [];
 
-    foreach ($block->childs as $child) {
+    foreach ($block->childs as $key => $child) {
         $mediaItem = [
             'media' => $child->imageAsArray('image', 'desktop'),
             'label' => $child->input('label'),
         ];
+
+        // Append full source for viewer
+        $mediaItem['media']['full_src'] = strtok($mediaItem['media']['src'], '?');
+
+        if ($child === $block->childs->first()) {
+            $cropRegion = array_intersect_key(
+                $mediaItem['media'],
+                array_flip(['crop_x', 'crop_y', 'width', 'height'])
+            );
+            $cropRegion['x'] = $cropRegion['crop_x'];
+            $cropRegion['y'] = $cropRegion['crop_y'];
+            unset($cropRegion['crop_x']);
+            unset($cropRegion['crop_y']);
+
+            $cropRegion = htmlspecialchars(json_encode($cropRegion), ENT_QUOTES, 'UTF-8');
+        }
 
         if ($child['type'] == 'layered_image_viewer_img') {
             $images[] = $mediaItem;
@@ -19,6 +34,7 @@
         if ($child['type'] == 'layered_image_viewer_overlay') {
             $overlays[] = $mediaItem;
         }
+
     }
 @endphp
 
@@ -30,5 +46,6 @@
         @slot('size', $size)
         @slot('images', $images)
         @slot('overlays', $overlays)
+        @slot('cropRegion', $cropRegion)
     @endcomponent
 @endif


### PR DESCRIPTION
Pivotal story: [184304798](https://www.pivotaltracker.com/story/show/184304798)
- Made some updates to the block and template files to get the data attribute for this coming out how I'd like.
- I added a new `full_src` key for each image, as it defaults to outputting the cropped image for `src`. Fortunately it just handles the crop with query parameters and removing those shows the original image.
- The story didn't ask for the reset functionality, the way I set this up means it was only a few simple lines to include this.
  - I would have liked to animate the reset zoom / pan, but there was an OSD bug which I've highlighted for future reference. 
