### PR TITLE
Scape AR from first image and use to set height

### DIFF
--- a/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
+++ b/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
@@ -19,6 +19,7 @@ class LayeredImageViewer {
     this.browerSupportsFullscreen =
       typeof document.fullscreenElement !== 'undefined';
     this.size = this.element.dataset.size || 'm';
+    this.aspect = 1;
     this.id = 0;
 
     this.captionTitleEl = null;
@@ -128,6 +129,11 @@ class LayeredImageViewer {
         if (typeof overlayEl.dataset.activeOverlay !== 'undefined') {
           this.overlays.default.push(i);
         }
+      }
+
+      // Use the first image to skim the aspect ratio
+      if (type === 'images' && i === 0) {
+        this.aspect = imgEl.height / imgEl.width;
       }
 
       // Add ID for internal reference
@@ -361,6 +367,9 @@ class LayeredImageViewer {
       '.o-layered-image-viewer__osd-mount'
     );
 
+    // Apect ratio for styling
+    this.osdMountEl.style.setProperty('--viewer-aspect', this.aspect);
+
     this.osdMountEl.style.display = 'block';
 
     // Add modal container if necessary (no fullscreen support)
@@ -390,6 +399,7 @@ class LayeredImageViewer {
         url: this.images.items[0].url, // First image from markup by default
       },
     });
+
     this.osdMountEl.style.display = '';
 
     this.viewer.addHandler('open', () => {

--- a/frontend/scss/organisms/_o-layered-image-viewer.scss
+++ b/frontend/scss/organisms/_o-layered-image-viewer.scss
@@ -268,6 +268,12 @@
 }
 
 // ---- Mouunted element
+.o-layered-image-viewer__osd {
+  .m-media__img {
+    display: flex;
+  }
+}
+
 .o-layered-image-viewer__osd-mount {
   width: 100%;
   // a11y: need min-height that doesn't allow buttons to overlap

--- a/frontend/scss/organisms/_o-layered-image-viewer.scss
+++ b/frontend/scss/organisms/_o-layered-image-viewer.scss
@@ -270,8 +270,14 @@
 // ---- Mouunted element
 .o-layered-image-viewer__osd-mount {
   width: 100%;
-  // a11y: Absolute min height as non-viewport relative
-  height: max(32em, 80vh);
+  // a11y: need min-height that doesn't allow buttons to overlap
+  min-height: 32em;
+  max-height: 80vh;
+  aspect-ratio: 1 / var(--viewer-aspect);
+
+  @supports not (aspect-ratio: 1) {
+    height: 80vh;
+  }
 }
 
 // Initial modal state


### PR DESCRIPTION
Takes the aspect ratio of the image, and the component width into account when deciding height of the viewer. The aspect ratio is based on the natural width / height of the image OR the width and height of the crop if used.