### PR TITLE
Layers UI broken when multiple instances have multiple layers

### DIFF
--- a/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
+++ b/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
@@ -149,8 +149,8 @@ class LayeredImageViewer {
    * @method
    */
   setInitialState() {
-    // Zero indexed ID of the viewer inferred from other instances in document
-    this.id = document.querySelectorAll('.o-layered-image-viewer').length - 1;
+    // Zero indexed ID of the viewer inferred from other initialised viewers document
+    this.id = document.querySelectorAll('.o-layered-image-viewer__osd').length - 1;
 
     // Set the size
     this.size = this.element.dataset.size;


### PR DESCRIPTION
The internal UID of the viewer was predicated on a query that would always return the same number.

Instead of querying the document for these root elements, it should have queried the document for evidence of previous initialisations.