### PR TITLE
Add basic dingo enclosure

### DIFF
--- a/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
+++ b/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
@@ -393,7 +393,10 @@ class LayeredImageViewer {
       showFullPageControl: false,
       visibilityRatio: 0.3,
       homeFillsViewer: false,
-      autoHideControls: false,
+      autoHideControls: true,
+      showNavigator: true,
+      navigatorPosition: 'TOP_LEFT',
+      navigatorAutoFade: true,
       tileSources: {
         type: 'image',
         url: this.images.items[0].url, // First image from markup by default


### PR DESCRIPTION
@tristanr-cogapp This appears to meet what was asked. It's an inbuilt OSD feature. It does autohide OTB, but only when the mouse is outside of the viewer area. Altering would be possible, but it would be custom and take time.