### PR TITLE
update reference to artwork images to include protocol

### DIFF
--- a/resources/views/site/customTour.blade.php
+++ b/resources/views/site/customTour.blade.php
@@ -97,7 +97,7 @@
                                         "restrict" => false,
                                     ];
                                 @endphp
-                                <a href="{{ config('app.url') }}/artworks/{{ $artwork['id'] }}"
+                                <a href="{{ config('aic.protocol') }}://{{ rtrim(config('app.url')) }}/artworks/{{ $artwork['id'] }}"
                                    aria-label="View full artwork page for {{ $artwork['title'] }}{{ isset($artwork['thumbnail']['alt_text']) ? ': ' . $artwork['thumbnail']['alt_text'] : '' }}">
                                     @component('components.atoms._img')
                                         @slot('image', $artwork_image)
@@ -143,7 +143,7 @@
                                 "{{ $artwork['objectNote'] }}"
                             @endcomponent
                         @endisset
-                        <a href="{{ config('app.url') }}/artworks/{{ $artwork['id'] }}"
+                        <a href="{{ config('aic.protocol') }}://{{ rtrim(config('app.url')) }}/artworks/{{ $artwork['id'] }}"
                            target="_blank"
                            class="external-link f-link"
                            aria-hidden="true">


### PR DESCRIPTION
- **Pivotal ticket**: [#186770094](https://www.pivotaltracker.com/story/show/186770094)

# What does this Pull Request do?

Locally, Cogapp had `https://` as part of the `APP_URL` env variable, so we were experiencing different behaviour than we're experiencing on the staging env.

See broken artwork links here:
https://www-staging.artic.edu/custom-tours/41

This PR updates the `<a>` tag to reference `aic.protocol` and uses `rtrim` on the `app.url` to provide a non-broken URL.

# Workflow

- [x] Before merging: After all review changes I've [synchronised `feature/custom-tours` and rebased this branch on top of it](https://docs.google.com/document/d/1FubzA4cTuC5tHL0cW3o8qdB8YFjRNi9RB-qRAHailJk/edit#heading=h.ws0snsaol9f8)
